### PR TITLE
Report test continuously for a single worker

### DIFF
--- a/src/teamcity.reporter.spec.ts
+++ b/src/teamcity.reporter.spec.ts
@@ -1,11 +1,16 @@
 import { FullConfig, TestError } from '@playwright/test';
-import { Suite } from '@playwright/test/reporter';
+import { Suite, TestResult, TestCase } from '@playwright/test/reporter';
 
 import TeamcityReporter from './teamcity.reporter';
 
-beforeAll(() => {
-  jest.spyOn(global.console, 'error');
-  jest.spyOn(global.console, 'log');
+const consoleLogSpy = jest.spyOn(global.console, 'log');
+const consoleInfoSpy = jest.spyOn(global.console, 'info');
+const consoleErrorSpy = jest.spyOn(global.console, 'error');
+
+afterEach(() => {
+  consoleLogSpy.mockReset();
+  consoleInfoSpy.mockReset();
+  consoleErrorSpy.mockReset();
 });
 
 describe(`TeamcityReporter`, () => {
@@ -38,7 +43,7 @@ describe(`TeamcityReporter`, () => {
       workers: 4,
       webServer: null
     };
-    const suite: Suite = {
+    const rootSuite: Suite = {
       location: undefined,
       parent: undefined,
       suites: [],
@@ -50,11 +55,11 @@ describe(`TeamcityReporter`, () => {
     };
 
     const reporter = new TeamcityReporter();
-    reporter.onBegin(config, suite);
+    reporter.onBegin(config, rootSuite);
 
     expect(reporter).toMatchObject({
       flowId: expect.any(String),
-      suite,
+      rootSuite,
     });
   });
 
@@ -93,7 +98,125 @@ describe(`TeamcityReporter`, () => {
     const reporter = new TeamcityReporter();
     reporter.onBegin(config, suite);
 
-    expect(console.log).toHaveBeenCalledWith(`'${JSON.stringify(config)}'`);
+    expect(console.info).toHaveBeenCalledWith(`'${JSON.stringify(config)}'`);
   });
 
+  test('reports test results continuously with a single worker', () => {
+    const test1 = {
+      title: 'test1',
+      results: [{
+        status: 'passed',
+        startTime: new Date(),
+        duration: 1,
+      } as TestResult],
+    } as TestCase;
+    const test2 = {
+      title: 'test2',
+      results: [{
+        status: 'passed',
+        startTime: new Date(),
+        duration: 2,
+      } as TestResult],
+    } as TestCase;
+
+    const suite1 = {
+      title: 'suite1',
+      tests: [test1],
+      suites: [] as Suite[],
+    } as Suite;
+    const suite2 = {
+      title: 'suite2',
+      tests: [test2],
+      suites: [] as Suite[],
+    } as Suite;
+    test1.parent = suite1;
+    test2.parent = suite2;
+
+    const rootSuite = {
+      suites: [ { suites: [suite1, suite2] } as Suite ],
+    } as Suite;
+    suite1.parent = { parent: rootSuite } as Suite;
+    suite2.parent = { parent: rootSuite } as Suite;
+
+    const reporter = new TeamcityReporter();
+
+    reporter.onBegin({ workers: 1 } as FullConfig, rootSuite);
+
+    reporter.onTestBegin(test1);
+    expect(console.log).not.toHaveBeenCalled();
+
+    reporter.onTestBegin(test2);
+    expect(console.log).toHaveBeenNthCalledWith(1, expect.stringContaining(`testSuiteStarted name='${test1.parent.title}'`));
+    expect(console.log).toHaveBeenNthCalledWith(2, expect.stringContaining(`testStarted name='${test1.title}'`));
+    expect(console.log).toHaveBeenNthCalledWith(3, expect.stringContaining(`testFinished name='${test1.title}'`));
+    expect(console.log).toHaveBeenNthCalledWith(4, expect.stringContaining(`testSuiteFinished name='${test1.parent.title}'`));
+    expect(console.log).toHaveBeenCalledTimes(4);
+
+    reporter.onEnd({ status: 'passed' });
+    expect(console.log).toHaveBeenNthCalledWith(5, expect.stringContaining(`testSuiteStarted name='${test2.parent.title}'`));
+    expect(console.log).toHaveBeenNthCalledWith(6, expect.stringContaining(`testStarted name='${test2.title}'`));
+    expect(console.log).toHaveBeenNthCalledWith(7, expect.stringContaining(`testFinished name='${test2.title}'`));
+    expect(console.log).toHaveBeenNthCalledWith(8, expect.stringContaining(`testSuiteFinished name='${test2.parent.title}'`));
+    expect(console.log).toHaveBeenCalledTimes(8);
+  });
+
+  test('reports test results only at the end with multiple workers', () => {
+    const test1 = {
+      title: 'test1',
+      results: [{
+        status: 'passed',
+        startTime: new Date(),
+        duration: 1,
+      } as TestResult],
+    } as TestCase;
+    const test2 = {
+      title: 'test2',
+      results: [{
+        status: 'passed',
+        startTime: new Date(),
+        duration: 2,
+      } as TestResult],
+    } as TestCase;
+
+    const suite1 = {
+      title: 'suite1',
+      tests: [test1],
+      suites: [] as Suite[],
+    } as Suite;
+    const suite2 = {
+      title: 'suite2',
+      tests: [test2],
+      suites: [] as Suite[],
+    } as Suite;
+    test1.parent = suite1;
+    test2.parent = suite2;
+
+    const rootSuite = {
+      suites: [ { suites: [suite1, suite2] } as Suite ],
+    } as Suite;
+    suite1.parent = { parent: rootSuite } as Suite;
+    suite2.parent = { parent: rootSuite } as Suite;
+
+    const reporter = new TeamcityReporter();
+
+    reporter.onBegin({} as FullConfig, rootSuite);
+    expect(console.info).toHaveBeenCalledWith('Playwright is running suites in multiple workers. The results will be reported after all of them finish.');
+
+    reporter.onTestBegin(test1);
+    expect(console.log).not.toHaveBeenCalled();
+
+    reporter.onTestBegin(test2);
+    expect(console.log).not.toHaveBeenCalled();
+
+    reporter.onEnd({ status: 'passed' });
+    expect(console.log).toHaveBeenNthCalledWith(1, expect.stringContaining(`testSuiteStarted name='${test1.parent.title}'`));
+    expect(console.log).toHaveBeenNthCalledWith(2, expect.stringContaining(`testStarted name='${test1.title}'`));
+    expect(console.log).toHaveBeenNthCalledWith(3, expect.stringContaining(`testFinished name='${test1.title}'`));
+    expect(console.log).toHaveBeenNthCalledWith(4, expect.stringContaining(`testSuiteFinished name='${test1.parent.title}'`));
+    expect(console.log).toHaveBeenNthCalledWith(5, expect.stringContaining(`testSuiteStarted name='${test2.parent.title}'`));
+    expect(console.log).toHaveBeenNthCalledWith(6, expect.stringContaining(`testStarted name='${test2.title}'`));
+    expect(console.log).toHaveBeenNthCalledWith(7, expect.stringContaining(`testFinished name='${test2.title}'`));
+    expect(console.log).toHaveBeenNthCalledWith(8, expect.stringContaining(`testSuiteFinished name='${test2.parent.title}'`));
+    expect(console.log).toHaveBeenCalledTimes(8);
+  });
 });

--- a/src/teamcity.reporter.ts
+++ b/src/teamcity.reporter.ts
@@ -21,8 +21,16 @@ class NotImplementedError extends Error {
 }
 
 class TeamcityReporter implements Reporter {
+  private readonly testMetadataArtifacts: string;
+
   private suite!: Suite;
   private flowId!: string;
+
+  constructor(configuration: Partial<{
+    testMetadataArtifacts: string;
+  }> = {}) {
+    this.testMetadataArtifacts = configuration.testMetadataArtifacts ?? process.env.TEAMCITY_ARTIFACTS_PW_RESULT ?? 'test-results';
+  }
 
   onBegin(config: FullConfig, suite: Suite) {
     this.flowId = process.pid.toString();
@@ -107,9 +115,7 @@ class TeamcityReporter implements Reporter {
 
     // https://www.jetbrains.com/help/teamcity/2021.2/reporting-test-metadata.html#Reporting+additional+test+data
     // 'test-results' should be a part of the artifacts directory
-    const artifact = process.env['TEAMCITY_ARTIFACTS_PW_RESULT'] !== undefined
-      ? process.env['TEAMCITY_ARTIFACTS_PW_RESULT']
-      : 'test-results';
+    const artifact = this.testMetadataArtifacts;
     for (const attachment of (result?.attachments || [])) {
       let value = '';
       if (attachment.path !== undefined) {


### PR DESCRIPTION
fix #1 

Originally I though the report could be made during each and every `onTestBegin` and `onTestEnd`, but that would only be true if the suites are not nested, which is realized is not always true. In this PR the tests should be reported after each test file finishes.