### PR TITLE
Continuous reporting with parallel testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,12 @@
   "packages": {
     "": {
       "name": "playwright-teamcity-reporter",
-      "version": "0.1.5",
-      "license": "ISC",
+      "version": "0.2.0",
+      "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.17.1",
         "@types/jest": "^27.0.3",
-        "@types/node": "^13.9.0",
+        "@types/node": "^14.0.0",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "auto-changelog": "^2.4.0",
@@ -1930,9 +1930,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "13.13.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==",
+      "version": "14.18.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.23.tgz",
+      "integrity": "sha512-MhbCWN18R4GhO8ewQWAFK4TGQdBpXWByukz7cWyJmXhvRuCIaM/oWytGPqVmDzgEnnaIc9ss6HbU5mUi+vyZPA==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -9712,9 +9712,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.13.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==",
+      "version": "14.18.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.23.tgz",
+      "integrity": "sha512-MhbCWN18R4GhO8ewQWAFK4TGQdBpXWByukz7cWyJmXhvRuCIaM/oWytGPqVmDzgEnnaIc9ss6HbU5mUi+vyZPA==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@playwright/test": "^1.17.1",
     "@types/jest": "^27.0.3",
-    "@types/node": "^13.9.0",
+    "@types/node": "^14.0.0",
     "@typescript-eslint/eslint-plugin": "^5.5.0",
     "@typescript-eslint/parser": "^5.5.0",
     "auto-changelog": "^2.4.0",

--- a/src/teamcity.model.ts
+++ b/src/teamcity.model.ts
@@ -1,4 +1,3 @@
-export type SuiteStatesType = 'testSuiteStarted' | 'testSuiteFinished';
 export type TestStatesType = 'testStarted'
   | 'testMetadata'
   | 'testFinished'
@@ -8,7 +7,6 @@ export type StdType = 'testStdOut' | 'testStdErr';
 
 export type ActionType = 'message'
   | 'testRetrySupport'
-  | SuiteStatesType
   | TestStatesType
   | StdType;
 

--- a/src/teamcity.model.ts
+++ b/src/teamcity.model.ts
@@ -14,8 +14,3 @@ export interface ITeamcityReporterConfiguration {
   testMetadataArtifacts?: string;
   logConfig?: boolean;
 }
-
-export enum ReporterMode {
-  Test,
-  Suite
-}

--- a/src/teamcity.reporter.spec.ts
+++ b/src/teamcity.reporter.spec.ts
@@ -130,27 +130,19 @@ describe(`TeamcityReporter`, () => {
         testFromSuiteB.results = [{ status: 'passed', startTime: new Date(), duration: 2 } as TestResult];
 
         expect(console.log)
-          .toHaveBeenNthCalledWith(1, expect.stringContaining(`testSuiteStarted name='${testFromSuiteA.parent.title}'`));
+          .toHaveBeenNthCalledWith(1, expect.stringContaining(`testStarted name='${testName(testFromSuiteA)}'`));
         expect(console.log)
-          .toHaveBeenNthCalledWith(2, expect.stringContaining(`testStarted name='${testName(testFromSuiteA)}'`));
+          .toHaveBeenNthCalledWith(2, expect.stringContaining(`testFinished name='${testName(testFromSuiteA)}'`));
         expect(console.log)
-          .toHaveBeenNthCalledWith(3, expect.stringContaining(`testFinished name='${testName(testFromSuiteA)}'`));
-        expect(console.log)
-          .toHaveBeenNthCalledWith(4, expect.stringContaining(`testSuiteFinished name='${testFromSuiteA.parent.title}'`));
-        expect(console.log)
-          .toHaveBeenCalledTimes(4);
+          .toHaveBeenCalledTimes(2);
 
         reporter.onEnd({ status: 'passed' });
         expect(console.log)
-          .toHaveBeenNthCalledWith(5, expect.stringContaining(`testSuiteStarted name='${testFromSuiteB.parent.title}'`));
+          .toHaveBeenNthCalledWith(3, expect.stringContaining(`testStarted name='${testName(testFromSuiteB)}'`));
         expect(console.log)
-          .toHaveBeenNthCalledWith(6, expect.stringContaining(`testStarted name='${testName(testFromSuiteB)}'`));
+          .toHaveBeenNthCalledWith(4, expect.stringContaining(`testFinished name='${testName(testFromSuiteB)}'`));
         expect(console.log)
-          .toHaveBeenNthCalledWith(7, expect.stringContaining(`testFinished name='${testName(testFromSuiteB)}'`));
-        expect(console.log)
-          .toHaveBeenNthCalledWith(8, expect.stringContaining(`testSuiteFinished name='${testFromSuiteB.parent.title}'`));
-        expect(console.log)
-          .toHaveBeenCalledTimes(8);
+          .toHaveBeenCalledTimes(4);
       });
 
       test('should reports test results only at the end with multiple workers', () => {
@@ -173,23 +165,15 @@ describe(`TeamcityReporter`, () => {
         reporter.onEnd({ status: 'passed' });
 
         expect(console.log)
-          .toHaveBeenNthCalledWith(1, expect.stringContaining(`testSuiteStarted name='${testFromSuiteA.parent.title}'`));
+          .toHaveBeenNthCalledWith(1, expect.stringContaining(`testStarted name='${testName(testFromSuiteA)}'`));
         expect(console.log)
-          .toHaveBeenNthCalledWith(2, expect.stringContaining(`testStarted name='${testName(testFromSuiteA)}'`));
+          .toHaveBeenNthCalledWith(2, expect.stringContaining(`testFinished name='${testName(testFromSuiteA)}'`));
         expect(console.log)
-          .toHaveBeenNthCalledWith(3, expect.stringContaining(`testFinished name='${testName(testFromSuiteA)}'`));
+          .toHaveBeenNthCalledWith(3, expect.stringContaining(`testStarted name='${testName(testFromSuiteB)}'`));
         expect(console.log)
-          .toHaveBeenNthCalledWith(4, expect.stringContaining(`testSuiteFinished name='${testFromSuiteA.parent.title}'`));
+          .toHaveBeenNthCalledWith(4, expect.stringContaining(`testFinished name='${testName(testFromSuiteB)}'`));
         expect(console.log)
-          .toHaveBeenNthCalledWith(5, expect.stringContaining(`testSuiteStarted name='${testFromSuiteB.parent.title}'`));
-        expect(console.log)
-          .toHaveBeenNthCalledWith(6, expect.stringContaining(`testStarted name='${testName(testFromSuiteB)}'`));
-        expect(console.log)
-          .toHaveBeenNthCalledWith(7, expect.stringContaining(`testFinished name='${testName(testFromSuiteB)}'`));
-        expect(console.log)
-          .toHaveBeenNthCalledWith(8, expect.stringContaining(`testSuiteFinished name='${testFromSuiteB.parent.title}'`));
-        expect(console.log)
-          .toHaveBeenCalledTimes(8);
+          .toHaveBeenCalledTimes(4);
       });
     });
 
@@ -214,21 +198,17 @@ describe(`TeamcityReporter`, () => {
       reporter.onEnd({ status: 'passed' });
 
       expect(console.log)
-        .toHaveBeenNthCalledWith(1, expect.stringContaining(`testSuiteStarted name='${testFromSuiteA.parent.title}'`));
+        .toHaveBeenNthCalledWith(1, expect.stringContaining(`testStarted name='${testName(testFromSuiteA)}'`));
       expect(console.log)
-        .toHaveBeenNthCalledWith(2, expect.stringContaining(`testStarted name='${testName(testFromSuiteA)}'`));
+        .toHaveBeenNthCalledWith(2, expect.stringContaining(`testFailed name='${testName(testFromSuiteA)}'`));
       expect(console.log)
-        .toHaveBeenNthCalledWith(3, expect.stringContaining(`testFailed name='${testName(testFromSuiteA)}'`));
+        .toHaveBeenNthCalledWith(3, expect.stringContaining(`testFinished name='${testName(testFromSuiteA)}'`));
       expect(console.log)
-        .toHaveBeenNthCalledWith(4, expect.stringContaining(`testFinished name='${testName(testFromSuiteA)}'`));
+        .toHaveBeenNthCalledWith(4, expect.stringContaining(`testStarted name='${testName(testFromSuiteA)}'`));
       expect(console.log)
-        .toHaveBeenNthCalledWith(5, expect.stringContaining(`testStarted name='${testName(testFromSuiteA)}'`));
+        .toHaveBeenNthCalledWith(5, expect.stringContaining(`testFinished name='${testName(testFromSuiteA)}'`));
       expect(console.log)
-        .toHaveBeenNthCalledWith(6, expect.stringContaining(`testFinished name='${testName(testFromSuiteA)}'`));
-      expect(console.log)
-        .toHaveBeenNthCalledWith(7, expect.stringContaining(`testSuiteFinished name='${testFromSuiteA.parent.title}'`));
-      expect(console.log)
-        .toHaveBeenCalledTimes(7);
+        .toHaveBeenCalledTimes(5);
     });
   });
 

--- a/src/teamcity.reporter.spec.ts
+++ b/src/teamcity.reporter.spec.ts
@@ -1,7 +1,7 @@
 import { FullConfig, FullProject, TestError } from '@playwright/test';
 import { Suite, TestCase, TestResult } from '@playwright/test/reporter';
 
-import TeamcityReporter, { escape } from './teamcity.reporter';
+import TeamcityReporter, { escape, testName } from './teamcity.reporter';
 import { stringify } from './utils';
 
 function titlePath(this: TestCase | Suite) {
@@ -132,9 +132,9 @@ describe(`TeamcityReporter`, () => {
         expect(console.log)
           .toHaveBeenNthCalledWith(1, expect.stringContaining(`testSuiteStarted name='${testFromSuiteA.parent.title}'`));
         expect(console.log)
-          .toHaveBeenNthCalledWith(2, expect.stringContaining(`testStarted name='${testFromSuiteA.title}'`));
+          .toHaveBeenNthCalledWith(2, expect.stringContaining(`testStarted name='${testName(testFromSuiteA)}'`));
         expect(console.log)
-          .toHaveBeenNthCalledWith(3, expect.stringContaining(`testFinished name='${testFromSuiteA.title}'`));
+          .toHaveBeenNthCalledWith(3, expect.stringContaining(`testFinished name='${testName(testFromSuiteA)}'`));
         expect(console.log)
           .toHaveBeenNthCalledWith(4, expect.stringContaining(`testSuiteFinished name='${testFromSuiteA.parent.title}'`));
         expect(console.log)
@@ -144,9 +144,9 @@ describe(`TeamcityReporter`, () => {
         expect(console.log)
           .toHaveBeenNthCalledWith(5, expect.stringContaining(`testSuiteStarted name='${testFromSuiteB.parent.title}'`));
         expect(console.log)
-          .toHaveBeenNthCalledWith(6, expect.stringContaining(`testStarted name='${testFromSuiteB.title}'`));
+          .toHaveBeenNthCalledWith(6, expect.stringContaining(`testStarted name='${testName(testFromSuiteB)}'`));
         expect(console.log)
-          .toHaveBeenNthCalledWith(7, expect.stringContaining(`testFinished name='${testFromSuiteB.title}'`));
+          .toHaveBeenNthCalledWith(7, expect.stringContaining(`testFinished name='${testName(testFromSuiteB)}'`));
         expect(console.log)
           .toHaveBeenNthCalledWith(8, expect.stringContaining(`testSuiteFinished name='${testFromSuiteB.parent.title}'`));
         expect(console.log)
@@ -175,17 +175,17 @@ describe(`TeamcityReporter`, () => {
         expect(console.log)
           .toHaveBeenNthCalledWith(1, expect.stringContaining(`testSuiteStarted name='${testFromSuiteA.parent.title}'`));
         expect(console.log)
-          .toHaveBeenNthCalledWith(2, expect.stringContaining(`testStarted name='${testFromSuiteA.title}'`));
+          .toHaveBeenNthCalledWith(2, expect.stringContaining(`testStarted name='${testName(testFromSuiteA)}'`));
         expect(console.log)
-          .toHaveBeenNthCalledWith(3, expect.stringContaining(`testFinished name='${testFromSuiteA.title}'`));
+          .toHaveBeenNthCalledWith(3, expect.stringContaining(`testFinished name='${testName(testFromSuiteA)}'`));
         expect(console.log)
           .toHaveBeenNthCalledWith(4, expect.stringContaining(`testSuiteFinished name='${testFromSuiteA.parent.title}'`));
         expect(console.log)
           .toHaveBeenNthCalledWith(5, expect.stringContaining(`testSuiteStarted name='${testFromSuiteB.parent.title}'`));
         expect(console.log)
-          .toHaveBeenNthCalledWith(6, expect.stringContaining(`testStarted name='${testFromSuiteB.title}'`));
+          .toHaveBeenNthCalledWith(6, expect.stringContaining(`testStarted name='${testName(testFromSuiteB)}'`));
         expect(console.log)
-          .toHaveBeenNthCalledWith(7, expect.stringContaining(`testFinished name='${testFromSuiteB.title}'`));
+          .toHaveBeenNthCalledWith(7, expect.stringContaining(`testFinished name='${testName(testFromSuiteB)}'`));
         expect(console.log)
           .toHaveBeenNthCalledWith(8, expect.stringContaining(`testSuiteFinished name='${testFromSuiteB.parent.title}'`));
         expect(console.log)
@@ -216,15 +216,15 @@ describe(`TeamcityReporter`, () => {
       expect(console.log)
         .toHaveBeenNthCalledWith(1, expect.stringContaining(`testSuiteStarted name='${testFromSuiteA.parent.title}'`));
       expect(console.log)
-        .toHaveBeenNthCalledWith(2, expect.stringContaining(`testStarted name='${testFromSuiteA.title}'`));
+        .toHaveBeenNthCalledWith(2, expect.stringContaining(`testStarted name='${testName(testFromSuiteA)}'`));
       expect(console.log)
-        .toHaveBeenNthCalledWith(3, expect.stringContaining(`testFailed name='${testFromSuiteA.title}'`));
+        .toHaveBeenNthCalledWith(3, expect.stringContaining(`testFailed name='${testName(testFromSuiteA)}'`));
       expect(console.log)
-        .toHaveBeenNthCalledWith(4, expect.stringContaining(`testFinished name='${testFromSuiteA.title}'`));
+        .toHaveBeenNthCalledWith(4, expect.stringContaining(`testFinished name='${testName(testFromSuiteA)}'`));
       expect(console.log)
-        .toHaveBeenNthCalledWith(5, expect.stringContaining(`testStarted name='${testFromSuiteA.title}'`));
+        .toHaveBeenNthCalledWith(5, expect.stringContaining(`testStarted name='${testName(testFromSuiteA)}'`));
       expect(console.log)
-        .toHaveBeenNthCalledWith(6, expect.stringContaining(`testFinished name='${testFromSuiteA.title}'`));
+        .toHaveBeenNthCalledWith(6, expect.stringContaining(`testFinished name='${testName(testFromSuiteA)}'`));
       expect(console.log)
         .toHaveBeenNthCalledWith(7, expect.stringContaining(`testSuiteFinished name='${testFromSuiteA.parent.title}'`));
       expect(console.log)

--- a/src/teamcity.reporter.spec.ts
+++ b/src/teamcity.reporter.spec.ts
@@ -1,7 +1,7 @@
 import { FullConfig, FullProject, TestError } from '@playwright/test';
 import { Suite, TestCase, TestResult } from '@playwright/test/reporter';
 
-import TeamcityReporter from './teamcity.reporter';
+import TeamcityReporter, { escape } from './teamcity.reporter';
 import { stringify } from './utils';
 
 function titlePath(this: TestCase | Suite) {
@@ -113,7 +113,7 @@ describe(`TeamcityReporter`, () => {
       reporter.onBegin(config, projectSuite);
 
       expect(console.log)
-        .not.toHaveBeenCalledWith(expect.stringContaining(`message text='${TeamcityReporter.escape(stringify(config))}'`));
+        .not.toHaveBeenCalledWith(expect.stringContaining(`message text='${escape(stringify(config))}'`));
     });
 
     describe('Modes::', () => {
@@ -242,7 +242,7 @@ describe(`TeamcityReporter`, () => {
       reporter.onBegin(config, projectSuite);
 
       expect(console.log)
-        .toHaveBeenCalledWith(expect.stringContaining(`message text='${TeamcityReporter.escape(stringify(config))}'`));
+        .toHaveBeenCalledWith(expect.stringContaining(`message text='${escape(stringify(config))}'`));
     });
   });
 });

--- a/src/teamcity.reporter.spec.ts
+++ b/src/teamcity.reporter.spec.ts
@@ -99,25 +99,15 @@ describe(`TeamcityReporter`, () => {
         .toBeCalledWith(error);
     });
 
-    test(`should store suite on begin`, () => {
-      reporter.onBegin(config, projectSuite);
-
-      expect(reporter)
-        .toMatchObject({
-          flowId: expect.any(String),
-          rootSuite: projectSuite,
-        });
-    });
-
     test('should not log configuration to console on begin by default', () => {
-      reporter.onBegin(config, projectSuite);
+      reporter.onBegin(config);
 
       expect(console.log)
         .not.toHaveBeenCalledWith(expect.stringContaining(`message text='${escape(stringify(config))}'`));
     });
 
     test('should reports test results continuously', () => {
-      reporter.onBegin({ ...config, workers: 2 }, projectSuite);
+      reporter.onBegin({ ...config, workers: 2 });
 
       jest.clearAllMocks();
       reporter.onTestBegin(testFromSuiteA);
@@ -166,7 +156,7 @@ describe(`TeamcityReporter`, () => {
         { status: 'passed', startTime: new Date(), duration: 1 } as TestResult
       ];
 
-      reporter.onBegin(configWithRetries, projectSuite);
+      reporter.onBegin(configWithRetries);
       expect(console.log)
         .toHaveBeenLastCalledWith(expect.stringContaining(`testRetrySupport enabled='true'`));
 
@@ -207,7 +197,7 @@ describe(`TeamcityReporter`, () => {
     });
 
     test('should log configuration to console on begin if requested', () => {
-      reporter.onBegin(config, projectSuite);
+      reporter.onBegin(config);
 
       expect(console.log)
         .toHaveBeenCalledWith(expect.stringContaining(`message text='${escape(stringify(config))}'`));

--- a/src/teamcity.reporter.ts
+++ b/src/teamcity.reporter.ts
@@ -13,7 +13,6 @@ class TeamcityReporter implements Reporter {
   flowId!: string;
   rootSuite!: Suite;
 
-  #config!: FullConfig;
   #mode!: ReporterMode;
   #lastRunningSuite: Suite | undefined;
 
@@ -25,7 +24,6 @@ class TeamcityReporter implements Reporter {
 
   onBegin(config: FullConfig, suite: Suite) {
     this.flowId = process.pid.toString();
-    this.#config = config;
     this.rootSuite = suite;
 
     if (config.workers === 1) {
@@ -36,11 +34,11 @@ class TeamcityReporter implements Reporter {
     }
 
     if (this.configuration?.logConfig) {
-      this.logToTC(`message`, [`text='${TeamcityReporter.escape(stringify(this.#config))}'`]);
+      this.logToTC(`message`, [`text='${TeamcityReporter.escape(stringify(config))}'`]);
     }
 
     // https://www.jetbrains.com/help/teamcity/service-messages.html#Enabling+Test+Retry
-    if (this.#config.projects.some(project => project.retries > 0)) {
+    if (config.projects.some(project => project.retries > 0)) {
       this.logToTC(`testRetrySupport`, [`enabled='true'`]);
     }
   }

--- a/src/teamcity.reporter.ts
+++ b/src/teamcity.reporter.ts
@@ -119,26 +119,9 @@ class TeamcityReporter implements Reporter {
     console.info(`Finished the run: ${result.status}`);
   }
 
-  logToTC(action: ActionType, parts: string[]) {
-    const textParts = [
-      `##teamcity[${action}`,
-      ...parts.filter(part => !!part),
-      `flowId='${this.flowId}']`
-    ];
-    console.log(textParts.join(' '));
-  }
-
   #logSuiteResults(suite: Suite): void {
-    this.logToTC(`testSuiteStarted`, [
-      `name='${escape(suite.title)}'`
-    ]);
-
     suite.tests.forEach((testCase: TestCase) => this.#logTestResults(testCase));
     suite.suites.forEach((suite: Suite) => this.#logSuiteResults(suite));
-
-    this.logToTC(`testSuiteFinished`, [
-      `name='${escape(suite.title)}'`
-    ]);
   }
 
   #logTestResults(test: TestCase) {

--- a/src/teamcity.reporter.ts
+++ b/src/teamcity.reporter.ts
@@ -67,10 +67,6 @@ class TeamcityReporter implements Reporter {
     }
   }
 
-  onError(error: TestError) {
-    console.error(error);
-  }
-
   onTestBegin(test: TestCase): void {
     this.#writeTestFlow(`testStarted`, test);
   }
@@ -89,10 +85,6 @@ class TeamcityReporter implements Reporter {
     } else {
       console.error(chunk);
     }
-  }
-
-  onEnd(result: FullResult) {
-    console.info(`Finished the run: ${result.status}`);
   }
 
   onTestEnd(test: TestCase, result: TestResult): void {
@@ -125,6 +117,14 @@ class TeamcityReporter implements Reporter {
     }
 
     this.#writeTestFlow(`testFinished`, test, { duration: `${result.duration}` });
+  }
+
+  onError(error: TestError): void {
+    console.error(error);
+  }
+
+  onEnd(result: FullResult): void {
+    console.info(`Finished the run: ${result.status}`);
   }
 
   #logAttachment(test: TestCase, attachment: TestResult['attachments'][number]): void {

--- a/src/teamcity.reporter.ts
+++ b/src/teamcity.reporter.ts
@@ -34,7 +34,7 @@ function writeServiceMessage(messageName: ActionType, parts: Record<string, stri
   console.log(`##teamcity[${messageName}${textParts}]`);
 }
 
-function testName(test: TestCase) {
+export function testName(test: TestCase) {
   // https://www.jetbrains.com/help/teamcity/2021.2/service-messages.html#Interpreting+Test+Names
   return test.titlePath().filter(title => title).join(': ');
 }

--- a/src/teamcity.reporter.ts
+++ b/src/teamcity.reporter.ts
@@ -26,6 +26,14 @@ export function escape(text: string): string {
   /* eslint-enable no-control-regex */
 }
 
+function writeServiceMessage(messageName: ActionType, parts: Record<string, string>): void {
+  const textParts = Object.entries(parts)
+    .map(([key, value]) => ` ${key}='${escape(value)}'`)
+    .join('');
+
+  console.log(`##teamcity[${messageName}${textParts}]`);
+}
+
 // https://www.jetbrains.com/help/teamcity/service-messages.html
 class TeamcityReporter implements Reporter {
   static readonly #TZ_OFFSET = (new Date()).getTimezoneOffset() * 60000; // offset in milliseconds
@@ -55,12 +63,12 @@ class TeamcityReporter implements Reporter {
     }
 
     if (this.configuration?.logConfig) {
-      this.logToTC(`message`, [`text='${escape(stringify(config))}'`]);
+      writeServiceMessage(`message`, { text: stringify(config) });
     }
 
     // https://www.jetbrains.com/help/teamcity/service-messages.html#Enabling+Test+Retry
     if (config.projects.some(project => project.retries > 0)) {
-      this.logToTC(`testRetrySupport`, [`enabled='true'`]);
+      writeServiceMessage(`testRetrySupport`, { enabled: `true` });
     }
   }
 

--- a/src/teamcity.reporter.ts
+++ b/src/teamcity.reporter.ts
@@ -52,6 +52,10 @@ class TeamcityReporter implements Reporter {
       ?? 'test-results';
   }
 
+  printsToStdio(): boolean {
+    return true;
+  }
+
   onBegin(config: FullConfig): void {
     if (this.configuration?.logConfig) {
       writeServiceMessage(`message`, { text: stringify(config) });
@@ -69,6 +73,22 @@ class TeamcityReporter implements Reporter {
 
   onTestBegin(test: TestCase): void {
     this.#writeTestFlow(`testStarted`, test);
+  }
+
+  onStdOut(chunk: string | Buffer, test?: TestCase): void {
+    if (test) {
+      this.#writeTestFlow(`testStdOut`, test, { out: chunk.toString() });
+    } else {
+      console.log(chunk);
+    }
+  }
+
+  onStdErr(chunk: string | Buffer, test?: TestCase): void {
+    if (test) {
+      this.#writeTestFlow(`testStdErr`, test, { out: chunk.toString() });
+    } else {
+      console.error(chunk);
+    }
   }
 
   onEnd(result: FullResult) {

--- a/src/teamcity.reporter.ts
+++ b/src/teamcity.reporter.ts
@@ -134,11 +134,11 @@ class TeamcityReporter implements Reporter {
   }
 
   #logTestResults(test: TestCase) {
-    const title = escape(test.title);
-    test.results.forEach((result: TestResult) => this.#logResult(title, result, test.timeout));
+    test.results.forEach((result: TestResult) => this.#logResult(test, result));
   }
 
-  #logResult(name: string, result: TestResult, timeout: number) {
+  #logResult(test: TestCase, result: TestResult) {
+    const name = escape(test.title);
     const localISOTime = new Date(result?.startTime.getTime() - TeamcityReporter.#TZ_OFFSET)
       .toISOString()
       .slice(0, -1);
@@ -158,7 +158,7 @@ class TeamcityReporter implements Reporter {
       case 'timedOut':
         this.logToTC(`testFailed`, [
           `name='${name}'`,
-          `message='Timeout of ${timeout}ms exceeded.'`,
+          `message='Timeout of ${test.timeout}ms exceeded.'`,
           `details='${escape(result?.error?.stack || '')}'`
         ]);
         break;


### PR DESCRIPTION
On one of the projects I am working on I run the tests in parallel, but I would like to have the feedback from Playwright ASAP.
I tried a couple of approaches to achieve that; this is the simplest one, i.e. the runner associates a flow to each test.
This makes it possible for each test to run concurrently with each other (even splitting a suite across multiple workers).

I am not sure if this approach is ok for this project, but I would like this feature ("instant" reporting of parallel test), so I went forward and tried to implement it.
FWIW, it seems to be working fine in my CI environment :)