### PR TITLE
Improve error feedback upon timeout

### DIFF
--- a/src/teamcity.reporter.ts
+++ b/src/teamcity.reporter.ts
@@ -65,8 +65,8 @@ class TeamcityReporter implements Reporter {
         break;
       case 'timedOut':
         this.#writeTestFlow(`testFailed`, test, {
-          message: `Timeout of ${test.timeout}ms exceeded.`,
-          details: `${result.error?.stack ?? ''}`,
+          message: `${result.error?.message ?? ''}`,
+          details: result.errors.map(e => e.message).join('\n'),
         });
         break;
       case 'failed':


### PR DESCRIPTION
The `error?.message` contains limited information, in the form of `Test timeout of XYZms exceeded.`.

Instead of repeating this in both message and details, enrich the content of details with the information from `errors`, so that the details point to the statement that timed out.

In a sample case I get:
```
Test timeout of 1000ms exceeded.
Error: page.waitForTimeout: Test timeout of 1000ms exceeded.

  3 | test('timeout', async ({ page }) => {
  4 |   test.setTimeout(1000);
> 5 |   await page.waitForTimeout(10000);
    |              ^
  6 | });
  7 |

    at /tests/example.spec.ts:5:14
```

