### PR TITLE
Improve error feedback upon timeout (v2)

### DIFF
--- a/src/teamcity.reporter.ts
+++ b/src/teamcity.reporter.ts
@@ -73,8 +73,8 @@ class TeamcityReporter implements Reporter {
         break;
       case "timedOut":
         this.#writeTestFlow("testFailed", test, {
-          message: `Timeout of ${test.timeout}ms exceeded.`,
-          details: `${result.error?.stack ?? ""}`,
+          message: `${result.error?.message ?? ""}`,
+          details: result.errors.map((e) => e.message).join("\n"),
         });
         break;
       case "failed":


### PR DESCRIPTION
Sorry to bother you again... the [commit](https://github.com/artemrudenko/playwright-teamcity-reporter/commit/2e26ae96d2466448ba18b3a00c301e3a39d22330) from #18 was apparently lost in a rebase.

I replayed it on top of the current `main` branch and aligned its syntax to the one from https://github.com/artemrudenko/playwright-teamcity-reporter/commit/25b719a4691930f653b8c5f2530f164e8c5459ea

Thank you a lot for your hard work and for the 1.0.1 release 🥳 .