### PR TITLE
have attachment of content type image to use the image type instead of artifact

### DIFF
--- a/src/teamcity.reporter.ts
+++ b/src/teamcity.reporter.ts
@@ -128,6 +128,8 @@ class TeamcityReporter implements Reporter {
     let type;
     switch (attachment.contentType) {
       case "image/png":
+        type = `type="image"`;
+        break;
       case "application/zip":
         type = `type="artifact"`;
         break;


### PR DESCRIPTION
TeamCity has an [image](https://www.jetbrains.com/help/teamcity/reporting-test-metadata.html#Images+from+Artifacts+Directory) type for test reports, which is useful for showing screenshots directly on TC.

Let me know if anything is missing to this PR, and I will gladly add it