### PR TITLE
fix #logAttachment function to pass correctly the attachment type

### DIFF
--- a/src/teamcity.reporter.ts
+++ b/src/teamcity.reporter.ts
@@ -116,6 +116,8 @@ class TeamcityReporter implements Reporter {
     // "test-results" should be a part of the artifacts directory
     let value = "";
     if (attachment.path !== undefined) {
+      if (attachment.path.indexOf("test-results") === -1) return;
+
       const artifact = this.#testMetadataArtifacts;
       value = attachment.path;
       value = value.split(path.sep).join(path.posix.sep);
@@ -128,14 +130,18 @@ class TeamcityReporter implements Reporter {
     let type;
     switch (attachment.contentType) {
       case "image/png":
-        type = `type="image"`;
+        type = "image";
+        break;
+      case "video/mp4":
+      case "video/webm":
+        type = "video";
         break;
       case "application/zip":
-        type = `type="artifact"`;
+        type = "artifact";
         break;
       case "application/json":
       default:
-        type = `type="text"`;
+        type = "text";
     }
 
     writeServiceMessage("testMetadata", {


### PR DESCRIPTION
Hi! I've noticed that current implementation of #logAttachment function has incorrect format of logging the attachment type into TeamCity testMetadata. Instead of logging, e.g. `type='image'`, it is currently logging `type='type="image"'`. 
https://www.jetbrains.com/help/teamcity/2021.2/reporting-test-metadata.html#Images+from+Artifacts+Directory

Moreover, if the attachment path doesn't contain the 'test-results' in itself, the logged path is breaked (which happens, e.g., for 'expected' screenshots when toHaveScreenshot test is failed).